### PR TITLE
feat: switch to config:best-practices

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     "customManagers:dockerfileVersions",
     "customManagers:githubActionsVersions",
     "helpers:pinGitHubActionDigestsToSemver"


### PR DESCRIPTION
Replaces `config:recommended` with `config:best-practices`, which extends it with:

- `docker:pinDigests` — maintains the `tag@sha256:` digests being introduced in renovate-config-debugger's Dockerfile (secustor/renovate-config-debugger#108)
- `:maintainLockFilesWeekly` — weekly lockfile maintenance, so in-range transitive vulnerability fixes (like the recent brace-expansion ReDoS) land without manual overrides
- `:pinDevDependencies`, `:configMigration`, `abandonments:recommended`, `security:minimumReleaseAgeNpm`

Notes:
- `helpers:pinGitHubActionDigestsToSemver` stays listed after it, so the semver-comment digest style keeps winning over best-practices' plain `helpers:pinGitHubActionDigests`.
- The existing 3-day `minimumReleaseAge` rule for non-secustor npm packages remains and is compatible with `security:minimumReleaseAgeNpm`.
- Validated with `renovate-config-validator` (no new warnings; the pre-existing `group:nodeJs` warning is untouched) and prettier.