### PR TITLE
feat: automerge lockfile maintenance

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,6 +7,10 @@
     "helpers:pinGitHubActionDigestsToSemver"
   ],
 
+  "lockFileMaintenance": {
+    "automerge": true
+  },
+
   "packageRules": [
     {
       "matchDatasources": ["npm"],


### PR DESCRIPTION
Follow-up to #173: `config:best-practices` brings `:maintainLockFilesWeekly`, so lockfile maintenance PRs will now appear weekly across repos. This automerges them, consistent with the existing automerge rules — they only merge when the consuming repo's CI passes, which is the real gate for transitive updates (e.g. the golden/shimmed byte-identical tests in renovate-config-debugger).